### PR TITLE
return original workflow ID in all responses

### DIFF
--- a/src/dial_dataclass/__init__.py
+++ b/src/dial_dataclass/__init__.py
@@ -7,4 +7,8 @@ from .dial_dataclass import (
     DialWorkflowCreationParamsClient,
     DialWorkflowDatasetUpdate,
 )
+from .dial_dataclass_responses import (
+    DialDataResponse1D,
+    DialDataResponse2D,
+)
 from .pydantic_helpers import ValidatedObjectId

--- a/src/dial_dataclass/dial_dataclass_responses.py
+++ b/src/dial_dataclass/dial_dataclass_responses.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+
+
+class DialDataResponse1D(BaseModel):
+    """Possible response from DIAL"""
+
+    data: list[float]
+    """Raw data"""
+    workflow_id: str
+    """The same workflow ID that was used to get the data, to facilitate possible load balancing."""
+
+
+class DialDataResponse2D(BaseModel):
+    """Possible response from DIAL"""
+
+    data: list[list[float]]
+    """Raw data"""
+    workflow_id: str
+    """The same workflow ID that was used to get the data, to facilitate possible load balancing."""


### PR DESCRIPTION
This will always return the workflow ID in the DIAL responses; you can use the Workflow ID to identify which workflow the DIAL response is associated with.

In the Client, after determining the operation (these checks should already exist), you can make the following changes.

## For `get_surrogate_values`, `get_next_point`, and `get_next_points`:

- the raw data can now be obtained by `payload['data']` instead of `payload` for the following functions:
- you can get the workflow ID by checking `payload['workflow_id']`

##   For `update_workflow_with_data`:

- the value of `payload` is now just the workflow_id, so you can check that to get the ID