### PR TITLE
fix: enable config option for existing secret ref

### DIFF
--- a/charts/dial/Chart.yaml
+++ b/charts/dial/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: dial
 description: "DIAL (Distributed INTERSECT Active Learning): An INTERSECT service that provides Bayesian optimization and active learning"
-version: 0.1.0
+version: 0.1.1
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/charts/dial/templates/deployment.yaml
+++ b/charts/dial/templates/deployment.yaml
@@ -136,7 +136,7 @@ spec:
       volumes:
         - name: dial-config
           secret:
-            secretName: {{ template "common.names.fullname" . }}-config
+            secretName: {{ if .Values.dial.configFileExistingSecret }}{{ .Values.dial.configFileExistingSecret }}{{ else }}{{ template "common.names.fullname" . }}-config{{ end }}
             items:
               - key: local-conf.json
                 path: local-conf.json

--- a/charts/dial/templates/secret-dial-config.yaml
+++ b/charts/dial/templates/secret-dial-config.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.dial.configFileExistingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,3 +11,4 @@ metadata:
 type: Opaque
 data:
   local-conf.json: {{ tpl .Values.dial.configFile . | b64enc | quote }}
+{{- end }}

--- a/charts/dial/values.yaml
+++ b/charts/dial/values.yaml
@@ -113,6 +113,10 @@ dial:
       }
     }
 
+  ### Provide an existing secret with key (local-conf.json)
+  ### NOTE: when this option is applied, the chart does not create the secret
+  configFileExistingSecret: ""
+
   diagnosticMode:
     enabled: false
     command:


### PR DESCRIPTION
This PR adds the `configFileExistingSecret` option to the `values.yaml` of the chart. Closes #32 