### PR TITLE
Expanded output for get_surrogate_values()

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -5,8 +5,10 @@ on:
     branches:
       - develop
       - main
+      # TODO remove this once this branch is merged into develop
+      - expanded-output
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
   workflow_dispatch:
 
 permissions:

--- a/scripts/1d_sable_client.py
+++ b/scripts/1d_sable_client.py
@@ -215,17 +215,16 @@ class ActiveLearningOrchestrator:
         )
 
     def handle_surrogate_values(self, payload):
-        response_data = payload['data']
+        means = payload['values']
+        transformed_stddevs = payload['transformed_stddevs']
         if self.at_grids:
-            self.stddev_grid = np.array(response_data[1]).reshape(
+            self.stddev_grid = np.array(transformed_stddevs).reshape(
                 (self.meshgrid_size,) * self.num_dims
             )
-            self.mean_grid = np.array(response_data[0]).reshape(
-                (self.meshgrid_size,) * self.num_dims
-            )
+            self.mean_grid = np.array(means).reshape((self.meshgrid_size,) * self.num_dims)
         else:
-            self.stddev_test = np.array(response_data[1])
-            self.mean_test = np.array(response_data[0])
+            self.stddev_test = np.array(transformed_stddevs)
+            self.mean_test = np.array(means)
             print(
                 f'Values at testing points {self.x_test.reshape(-1)}: Mean: {self.mean_test}, Stddev: {self.stddev_test}'
             )

--- a/scripts/1d_sinusoidal_growth_client.py
+++ b/scripts/1d_sinusoidal_growth_client.py
@@ -187,17 +187,16 @@ class ActiveLearningOrchestrator:
         )
 
     def handle_surrogate_values(self, payload):
-        response_data = payload['data']
+        means = payload['values']
+        transformed_stddevs = payload['transformed_stddevs']
         if self.at_grids:
-            self.variance_grid = np.array(response_data[1]).reshape(
+            self.variance_grid = np.array(transformed_stddevs).reshape(
                 (self.meshgrid_size,) * self.num_dims
             )
-            self.mean_grid = np.array(response_data[0]).reshape(
-                (self.meshgrid_size,) * self.num_dims
-            )
+            self.mean_grid = np.array(means).reshape((self.meshgrid_size,) * self.num_dims)
         else:
-            self.variance_test = np.array(response_data[1])
-            self.mean_test = np.array(response_data[0])
+            self.variance_test = np.array(transformed_stddevs)
+            self.mean_test = np.array(means)
             print(f'Test Mean: {self.mean_test}, Variance: {self.variance_test}')
 
         # end of active learning loop after max_iter

--- a/scripts/2d_rosenbrock_client.py
+++ b/scripts/2d_rosenbrock_client.py
@@ -208,8 +208,8 @@ class ActiveLearningOrchestrator:
         if (
             operation == 'dial.get_surrogate_values'
         ):  # if we receive a grid of surrogate values, record it for graphing, then ask for the next recommended point
-            data = payload['data']
-            self.mean_grid = np.array(data[0]).reshape((MESHGRID_SIZE,) * NUM_DIMS)
+            means = payload['values']
+            self.mean_grid = np.array(means).reshape((MESHGRID_SIZE,) * NUM_DIMS)
             return self.assemble_message('get_next_point')
 
         if operation == 'dial.get_next_point':

--- a/scripts/manual_client.py
+++ b/scripts/manual_client.py
@@ -187,7 +187,7 @@ class ActiveLearningOrchestrator:
         if (
             operation == 'dial.get_surrogate_values'
         ):  # if we receive a grid of surrogate values, record it for graphing, then ask for the next recommended point
-            self.mean_grid = np.array(payload[0]).reshape(XX.shape)
+            self.mean_grid = np.array(payload['values']).reshape(XX.shape)
             return self.assemble_message('get_next_point')
         if operation == 'dial.get_next_point':
             # if we receive an EI recommendation, record it, show the user the current graph, and ask the user for the results of their experiment:

--- a/src/dial_dataclass/__init__.py
+++ b/src/dial_dataclass/__init__.py
@@ -13,5 +13,6 @@ from .dial_dataclass_responses import (
     DialDataResponse1D,
     DialDataResponse2D,
     DialSurrogateValuesResponse,
+    DialWorkflowFullState,
 )
 from .pydantic_helpers import ValidatedObjectId

--- a/src/dial_dataclass/__init__.py
+++ b/src/dial_dataclass/__init__.py
@@ -12,5 +12,6 @@ from .dial_dataclass import (
 from .dial_dataclass_responses import (
     DialDataResponse1D,
     DialDataResponse2D,
+    DialSurrogateValuesResponse,
 )
 from .pydantic_helpers import ValidatedObjectId

--- a/src/dial_dataclass/dial_dataclass.py
+++ b/src/dial_dataclass/dial_dataclass.py
@@ -164,6 +164,7 @@ class DialInputSingleOtherStrategy(BaseModel):
     workflow_id: ValidatedObjectId
     strategy: Literal[
         'random',
+        'hypercube',
         'uncertainty',
         'expected_improvement',
         'upper_confidence_bound',

--- a/src/dial_dataclass/dial_dataclass.py
+++ b/src/dial_dataclass/dial_dataclass.py
@@ -158,6 +158,13 @@ class DialInputSingleConfidenceBound(BaseModel):
     confidence_bound: float = Field(gt=0.5, lt=1)
     discrete_measurements: bool = Field(default=False)
     discrete_measurement_grid_size: list[PositiveIntType] = Field(default=[20, 20])
+    point_index: Annotated[
+        PositiveIntType,
+        Field(
+            default=0,
+            description='If using a strategy (i.e. "hypercube") which generates multiple points, get the specific point via the index (0-based) (default: 0)',
+        ),
+    ]
 
 
 class DialInputSingleOtherStrategy(BaseModel):
@@ -201,6 +208,13 @@ class DialInputSingleOtherStrategy(BaseModel):
     optimization_points: PositiveIntType = Field(default=1000)
     discrete_measurements: bool = Field(default=False)
     discrete_measurement_grid_size: list[PositiveIntType] = Field(default=[20, 20])
+    point_index: Annotated[
+        PositiveIntType,
+        Field(
+            default=0,
+            description='If using a strategy (i.e. "hypercube") which generates multiple points, get the specific point via the index (0-based) (default: 0)',
+        ),
+    ]
 
 
 DialInputSingle = Annotated[

--- a/src/dial_dataclass/dial_dataclass_responses.py
+++ b/src/dial_dataclass/dial_dataclass_responses.py
@@ -48,3 +48,5 @@ class DialSurrogateValuesResponse(BaseModel):
     """The same workflow ID that was used to get the data, to facilitate possible load balancing."""
     dataset_x_size: int
     """Current length of dataset_x"""
+    transformed_stddevs_avg: float
+    """the average of the transformed stddevs being returned"""

--- a/src/dial_dataclass/dial_dataclass_responses.py
+++ b/src/dial_dataclass/dial_dataclass_responses.py
@@ -2,9 +2,16 @@ from typing import Annotated
 
 from pydantic import BaseModel, Field
 
+from .dial_dataclass import DialWorkflowCreationParamsClient
 from .pydantic_helpers import ValidatedObjectId
 
 PositiveIntType = Annotated[int, Field(ge=0)]
+
+
+class DialWorkflowFullState(DialWorkflowCreationParamsClient):
+    """Full state of the workflow."""
+
+    workflow_id: ValidatedObjectId
 
 
 class DialDataResponse1D(BaseModel):

--- a/src/dial_dataclass/dial_dataclass_responses.py
+++ b/src/dial_dataclass/dial_dataclass_responses.py
@@ -12,6 +12,8 @@ class DialWorkflowFullState(DialWorkflowCreationParamsClient):
     """Full state of the workflow."""
 
     workflow_id: ValidatedObjectId
+    dataset_x_size: int
+    """Current length of dataset_x"""
 
 
 class DialDataResponse1D(BaseModel):

--- a/src/dial_dataclass/dial_dataclass_responses.py
+++ b/src/dial_dataclass/dial_dataclass_responses.py
@@ -14,6 +14,8 @@ class DialDataResponse1D(BaseModel):
     """Raw data"""
     workflow_id: ValidatedObjectId
     """The same workflow ID that was used to get the data, to facilitate possible load balancing."""
+    dataset_x_size: int
+    """Current length of dataset_x"""
 
 
 class DialDataResponse2D(BaseModel):
@@ -23,6 +25,8 @@ class DialDataResponse2D(BaseModel):
     """Raw data"""
     workflow_id: ValidatedObjectId
     """The same workflow ID that was used to get the data, to facilitate possible load balancing."""
+    dataset_x_size: int
+    """Current length of dataset_x"""
 
 
 class DialSurrogateValuesResponse(BaseModel):
@@ -42,3 +46,5 @@ class DialSurrogateValuesResponse(BaseModel):
     """Original list of points provided from the get_surrogate_values() input"""
     workflow_id: ValidatedObjectId
     """The same workflow ID that was used to get the data, to facilitate possible load balancing."""
+    dataset_x_size: int
+    """Current length of dataset_x"""

--- a/src/dial_dataclass/dial_dataclass_responses.py
+++ b/src/dial_dataclass/dial_dataclass_responses.py
@@ -1,6 +1,10 @@
-from pydantic import BaseModel
+from typing import Annotated
+
+from pydantic import BaseModel, Field
 
 from .pydantic_helpers import ValidatedObjectId
+
+PositiveIntType = Annotated[int, Field(ge=0)]
 
 
 class DialDataResponse1D(BaseModel):
@@ -17,5 +21,24 @@ class DialDataResponse2D(BaseModel):
 
     data: list[list[float]]
     """Raw data"""
+    workflow_id: ValidatedObjectId
+    """The same workflow ID that was used to get the data, to facilitate possible load balancing."""
+
+
+class DialSurrogateValuesResponse(BaseModel):
+    """Response structure from calling get_surrogate_values()"""
+
+    values: list[float]
+    """The computed values (for example, from Gaussian backends, the means) from calling get_surrogate_values()"""
+    transformed_stddevs: list[float]
+    """The computed uncertainties from calling get_surrogate_values(), with an inverse transform. If inverse-transforming is not possible (due to log-preprocessing), this will be all -1"""
+    stddevs: list[float]  # TODO will probably remove in future
+    """The computed raw uncertainties from calling get_surrogate_values(), without an inverse transform"""
+    dim_x: int
+    """Number of dimensions of the associated data, derived from workflow"""
+    bounds: list[list[float]]
+    """Bounding box of the data, derived from workflow"""
+    points_to_predict: list[list[float]]
+    """Original list of points provided from the get_surrogate_values() input"""
     workflow_id: ValidatedObjectId
     """The same workflow ID that was used to get the data, to facilitate possible load balancing."""

--- a/src/dial_service/core.py
+++ b/src/dial_service/core.py
@@ -50,12 +50,9 @@ def get_next_point(data: ServersideInputSingle, model: Any) -> list[float]:
         if not data.discrete_measurements:
             # use sane default
             data.discrete_measurement_grid_size = [4] * data.dim_x
-        if not hasattr(data, 'curr_index'):
-            data.curr_index = 0
         _measurement_grid = create_measurement_grid(data)
-        index = data.curr_index % len(_measurement_grid)
+        index = data.point_index % len(_measurement_grid)
         selected_point = _measurement_grid[index]
-        data.curr_index += 1
         logger.debug('selected point with hypercube strategy')
         logger.debug(selected_point)
         return selected_point

--- a/src/dial_service/core.py
+++ b/src/dial_service/core.py
@@ -46,7 +46,7 @@ def get_next_point(data: ServersideInputSingle, model: Any) -> list[float]:
             return selected_point
         return random_in_bounds(data.bounds, data.numpy_rng)
 
-    if data.strategy == 'grid':
+    if data.strategy == 'hypercube':
         if hasattr(data, 'curr_index'):
             data.curr_index += 1
         else:            
@@ -54,7 +54,7 @@ def get_next_point(data: ServersideInputSingle, model: Any) -> list[float]:
         _measurement_grid = create_measurement_grid(data)
         index = data.curr_index % len(_measurement_grid)
         selected_point = _measurement_grid[index]
-        logger.debug('selected point with grid strategy')
+        logger.debug('selected point with hypercube strategy')
         logger.debug(selected_point)
         return selected_point
 

--- a/src/dial_service/core.py
+++ b/src/dial_service/core.py
@@ -96,7 +96,9 @@ def get_next_points(data: ServersideInputMultiple, model: Any) -> list[list[floa
 
 
 # pure functional implementation of message, without MongoDB calls
-def get_surrogate_values(data: ServersideInputPrediction, model: Any) -> list[list[float]]:
+def get_surrogate_values(
+    data: ServersideInputPrediction, model: Any
+) -> tuple[list[float], list[float], list[float], float]:
     """
     Get surrogate model predictions for given input points.
 
@@ -106,14 +108,15 @@ def get_surrogate_values(data: ServersideInputPrediction, model: Any) -> list[li
         client_data (DialInputPredictions): Input data containing prediction points and model parameters.
 
     Returns:
-        list[list[float]]: A list containing means, transformed standard deviations, and raw standard deviations.
+        tuple[list[float], list[float], list[float], float]: A tuple containing means, transformed standard deviations, raw standard deviations, and a float value.
     """
     backend = data.backend.lower()
     module = get_backend_module(backend)
     means, stddevs = module.predict(model, data)
     means = data.inverse_transform(means)
     transformed_stddevs = data.inverse_transform(stddevs, is_stddev=True)
-    return [means.tolist(), transformed_stddevs.tolist(), stddevs.tolist()]
+    average = np.sqrt(np.mean(np.asarray(transformed_stddevs) ** 2))
+    return (means.tolist(), transformed_stddevs.tolist(), stddevs.tolist(), float(average))
 
 
 def train_model(data: ServersideInputBase) -> Any:

--- a/src/dial_service/core.py
+++ b/src/dial_service/core.py
@@ -47,13 +47,14 @@ def get_next_point(data: ServersideInputSingle, model: Any) -> list[float]:
         return random_in_bounds(data.bounds, data.numpy_rng)
 
     if data.strategy == 'hypercube':
-        if hasattr(data, 'curr_index'):
-            data.curr_index += 1
-        else:            
+        if not data.discrete_measurements:
+            data.discrete_measurement_grid_size = 10
+        if not hasattr(data, 'curr_index'):
             data.curr_index = 0
         _measurement_grid = create_measurement_grid(data)
         index = data.curr_index % len(_measurement_grid)
         selected_point = _measurement_grid[index]
+        data.curr_index += 1
         logger.debug('selected point with hypercube strategy')
         logger.debug(selected_point)
         return selected_point

--- a/src/dial_service/core.py
+++ b/src/dial_service/core.py
@@ -46,6 +46,18 @@ def get_next_point(data: ServersideInputSingle, model: Any) -> list[float]:
             return selected_point
         return random_in_bounds(data.bounds, data.numpy_rng)
 
+    if data.strategy == 'grid':
+        if hasattr(data, 'curr_index'):
+            data.curr_index += 1
+        else:            
+            data.curr_index = 0
+        _measurement_grid = create_measurement_grid(data)
+        index = data.curr_index % len(_measurement_grid)
+        selected_point = _measurement_grid[index]
+        logger.debug('selected point with grid strategy')
+        logger.debug(selected_point)
+        return selected_point
+
     backend = data.backend.lower()
     module = get_backend_module(backend)
     selected_point = module.sample(module, model, data)

--- a/src/dial_service/core.py
+++ b/src/dial_service/core.py
@@ -48,7 +48,8 @@ def get_next_point(data: ServersideInputSingle, model: Any) -> list[float]:
 
     if data.strategy == 'hypercube':
         if not data.discrete_measurements:
-            data.discrete_measurement_grid_size = 10
+            # use sane default
+            data.discrete_measurement_grid_size = [4] * data.dim_x
         if not hasattr(data, 'curr_index'):
             data.curr_index = 0
         _measurement_grid = create_measurement_grid(data)

--- a/src/dial_service/dial_service.py
+++ b/src/dial_service/dial_service.py
@@ -1,6 +1,5 @@
 import logging
 import pickle
-import statistics
 import traceback
 from typing import Any
 
@@ -351,7 +350,7 @@ class DialCapabilityImplementation(IntersectBaseCapabilityImplementation):
                 bounds=validated_state.bounds,
                 workflow_id=client_data.workflow_id,
                 dataset_x_size=len(validated_state.dataset_x),
-                transformed_stddevs_avg=statistics.mean(return_data[1]),
+                transformed_stddevs_avg=return_data[3],
             )
         except Exception as err:
             logger.exception(

--- a/src/dial_service/dial_service.py
+++ b/src/dial_service/dial_service.py
@@ -82,7 +82,11 @@ class DialCapabilityImplementation(IntersectBaseCapabilityImplementation):
         if not db_result:
             msg = f"Couldn't get workflow data with id {uuid}"
             raise IntersectCapabilityError(msg)
-        return DialWorkflowFullState(workflow_id=uuid, **db_result)
+        return DialWorkflowFullState(
+            workflow_id=uuid,
+            dataset_x_size=len(db_result['dataset_x']),
+            **db_result,
+        )
 
     @intersect_message()
     def update_workflow_with_data(

--- a/src/dial_service/dial_service.py
+++ b/src/dial_service/dial_service.py
@@ -245,6 +245,7 @@ class DialCapabilityImplementation(IntersectBaseCapabilityImplementation):
             return DialDataResponse1D(
                 data=return_data,
                 workflow_id=client_data.workflow_id,
+                dataset_x_size=len(validated_state.dataset_x),
             )
         except Exception as err:
             logger.exception(
@@ -290,6 +291,7 @@ class DialCapabilityImplementation(IntersectBaseCapabilityImplementation):
             return DialDataResponse2D(
                 data=return_data,
                 workflow_id=client_data.workflow_id,
+                dataset_x_size=len(validated_state.dataset_x),
             )
         except Exception as err:
             logger.exception(
@@ -342,6 +344,7 @@ class DialCapabilityImplementation(IntersectBaseCapabilityImplementation):
                 points_to_predict=client_data.points_to_predict,
                 bounds=validated_state.bounds,
                 workflow_id=client_data.workflow_id,
+                dataset_x_size=len(validated_state.dataset_x),
             )
         except Exception as err:
             logger.exception(

--- a/src/dial_service/dial_service.py
+++ b/src/dial_service/dial_service.py
@@ -1,5 +1,6 @@
 import logging
 import pickle
+import statistics
 import traceback
 from typing import Any
 
@@ -345,6 +346,7 @@ class DialCapabilityImplementation(IntersectBaseCapabilityImplementation):
                 bounds=validated_state.bounds,
                 workflow_id=client_data.workflow_id,
                 dataset_x_size=len(validated_state.dataset_x),
+                transformed_stddevs_avg=statistics.mean(return_data[1]),
             )
         except Exception as err:
             logger.exception(

--- a/src/dial_service/dial_service.py
+++ b/src/dial_service/dial_service.py
@@ -20,6 +20,7 @@ from dial_dataclass import (
     DialSurrogateValuesResponse,
     DialWorkflowDatasetUpdate,
     DialWorkflowDatasetUpdates,
+    DialWorkflowFullState,
 )
 from dial_dataclass.pydantic_helpers import ValidatedObjectId
 
@@ -71,7 +72,7 @@ class DialCapabilityImplementation(IntersectBaseCapabilityImplementation):
         return workflow_id
 
     @intersect_message()
-    def get_workflow_data(self, uuid: ValidatedObjectId) -> DialWorkflowCreationParamsService:
+    def get_workflow_data(self, uuid: ValidatedObjectId) -> DialWorkflowFullState:
         """Returns the current state of the workflow associated with the id"""
         try:
             db_result = self.mongo_handler.get_workflow(uuid)
@@ -81,7 +82,7 @@ class DialCapabilityImplementation(IntersectBaseCapabilityImplementation):
         if not db_result:
             msg = f"Couldn't get workflow data with id {uuid}"
             raise IntersectCapabilityError(msg)
-        return DialWorkflowCreationParamsService(**db_result)
+        return DialWorkflowFullState(workflow_id=uuid, **db_result)
 
     @intersect_message()
     def update_workflow_with_data(

--- a/src/dial_service/dial_service.py
+++ b/src/dial_service/dial_service.py
@@ -16,6 +16,7 @@ from dial_dataclass import (
     DialInputMultiple,
     DialInputPredictions,
     DialInputSingle,
+    DialSurrogateValuesResponse,
     DialWorkflowDatasetUpdate,
     DialWorkflowDatasetUpdates,
 )
@@ -101,7 +102,8 @@ class DialCapabilityImplementation(IntersectBaseCapabilityImplementation):
             pretrain_result = DialWorkflowCreationParamsService(**db_get_result)
         except Exception:
             logger.exception(
-                'update_workflow validation exception for %s', update_params.workflow_id
+                'update_workflow validation exception for %s',
+                update_params.workflow_id,
             )
             pretrain_result = None
         if not pretrain_result or (
@@ -146,7 +148,10 @@ class DialCapabilityImplementation(IntersectBaseCapabilityImplementation):
                 update_params.workflow_id, include_model=True
             )
         except Exception:
-            logger.exception('update_workflow_with_batch_data init %s', update_params.workflow_id)
+            logger.exception(
+                'update_workflow_with_batch_data init %s',
+                update_params.workflow_id,
+            )
             db_get_result = None
         if not db_get_result:
             exc = f'Could not get workflow with id {update_params.workflow_id}'
@@ -156,7 +161,8 @@ class DialCapabilityImplementation(IntersectBaseCapabilityImplementation):
             pretrain = DialWorkflowCreationParamsService(**db_get_result)
         except Exception:
             logger.exception(
-                'update_workflow_with_batch_data validation %s', update_params.workflow_id
+                'update_workflow_with_batch_data validation %s',
+                update_params.workflow_id,
             )
             pretrain = None
         if not pretrain:
@@ -190,7 +196,8 @@ class DialCapabilityImplementation(IntersectBaseCapabilityImplementation):
             )
         except Exception:
             logger.exception(
-                'update_workflow_with_batch_data training %s', update_params.workflow_id
+                'update_workflow_with_batch_data training %s',
+                update_params.workflow_id,
             )
             db_update_result = None
         if not db_update_result:
@@ -216,7 +223,8 @@ class DialCapabilityImplementation(IntersectBaseCapabilityImplementation):
             workflow_state = self.mongo_handler.get_workflow(client_data.workflow_id)
         except Exception:
             logger.exception(
-                'get_next_point exception (state initialization) for %s', client_data.workflow_id
+                'get_next_point exception (state initialization) for %s',
+                client_data.workflow_id,
             )
             workflow_state = None
         if not workflow_state:
@@ -240,7 +248,8 @@ class DialCapabilityImplementation(IntersectBaseCapabilityImplementation):
             )
         except Exception as err:
             logger.exception(
-                'get_next_point exception (primary logic) for %s', client_data.workflow_id
+                'get_next_point exception (primary logic) for %s',
+                client_data.workflow_id,
             )
             raise IntersectCapabilityError(traceback.format_exc()) from err
 
@@ -259,7 +268,8 @@ class DialCapabilityImplementation(IntersectBaseCapabilityImplementation):
             workflow_state = self.mongo_handler.get_workflow(client_data.workflow_id)
         except Exception:
             logger.exception(
-                'get_next_pointS exception (state initialization) for %s', client_data.workflow_id
+                'get_next_pointS exception (state initialization) for %s',
+                client_data.workflow_id,
             )
             workflow_state = None
         if not workflow_state:
@@ -283,16 +293,21 @@ class DialCapabilityImplementation(IntersectBaseCapabilityImplementation):
             )
         except Exception as err:
             logger.exception(
-                'get_next_pointS exception (primary logic) for %s', client_data.workflow_id
+                'get_next_pointS exception (primary logic) for %s',
+                client_data.workflow_id,
             )
             raise IntersectCapabilityError(traceback.format_exc()) from err
 
     @intersect_message
-    def get_surrogate_values(self, client_data: DialInputPredictions) -> DialDataResponse2D:
+    def get_surrogate_values(
+        self, client_data: DialInputPredictions
+    ) -> DialSurrogateValuesResponse:
         """Trains a model then returns 3 lists based on user-supplied points:
-        -Index 0: Predicted values.  These are inverse transformed (undoing the preprocessing to put them on the same scale as dataset_y)
-        -Index 1: Inverse-transformed uncertainties.  If inverse-transforming is not possible (due to log-preprocessing), this will be all -1
-        -Index 2: Uncertainties without inverse transformation
+        - Predicted values.  These are inverse transformed (undoing the preprocessing to put them on the same scale as dataset_y)
+        - Inverse-transformed uncertainties.  If inverse-transforming is not possible (due to log-preprocessing), this will be all -1
+        - Uncertainties without inverse transformation
+
+        Additional metadata is also returned in the response.
         """
         try:
             workflow_state = self.mongo_handler.get_workflow(
@@ -319,13 +334,19 @@ class DialCapabilityImplementation(IntersectBaseCapabilityImplementation):
             data = ServersideInputPrediction(validated_state, client_data)
 
             return_data = core.get_surrogate_values(data, model)
-            return DialDataResponse2D(
-                data=return_data,
+            return DialSurrogateValuesResponse(
+                values=return_data[0],
+                transformed_stddevs=return_data[1],
+                stddevs=return_data[2],
+                dim_x=validated_state.dim_x,
+                points_to_predict=client_data.points_to_predict,
+                bounds=validated_state.bounds,
                 workflow_id=client_data.workflow_id,
             )
         except Exception as err:
             logger.exception(
-                'get_surrogate_values exception (primary logic) for %s', client_data.workflow_id
+                'get_surrogate_values exception (primary logic) for %s',
+                client_data.workflow_id,
             )
             raise IntersectCapabilityError(traceback.format_exc()) from err
 

--- a/src/dial_service/serverside_data.py
+++ b/src/dial_service/serverside_data.py
@@ -95,7 +95,11 @@ class ServersideInputBase:
 
 
 class ServersideInputSingle(ServersideInputBase):
-    def __init__(self, workflow_state: DialWorkflowCreationParamsService, params: DialInputSingle):
+    def __init__(
+        self,
+        workflow_state: DialWorkflowCreationParamsService,
+        params: DialInputSingle,
+    ):
         super().__init__(workflow_state)
         self.strategy = params.strategy
         self.strategy_args = params.strategy_args
@@ -109,6 +113,7 @@ class ServersideInputSingle(ServersideInputBase):
         )
         self.discrete_measurements = params.discrete_measurements
         self.discrete_measurement_grid_size = params.discrete_measurement_grid_size
+        self.point_index = params.point_index
 
     def set_x_predict(self, X_raw: np.ndarray) -> None:
         """
@@ -121,7 +126,9 @@ class ServersideInputSingle(ServersideInputBase):
 
 class ServersideInputMultiple(ServersideInputBase):
     def __init__(
-        self, workflow_state: DialWorkflowCreationParamsService, params: DialInputMultiple
+        self,
+        workflow_state: DialWorkflowCreationParamsService,
+        params: DialInputMultiple,
     ):
         super().__init__(workflow_state)
         self.strategy = params.strategy
@@ -150,7 +157,9 @@ class ServersideInputMultiple(ServersideInputBase):
 
 class ServersideInputPrediction(ServersideInputBase):
     def __init__(
-        self, workflow_state: DialWorkflowCreationParamsService, params: DialInputPredictions
+        self,
+        workflow_state: DialWorkflowCreationParamsService,
+        params: DialInputPredictions,
     ):
         super().__init__(workflow_state)
         self.x_predict_raw = np.asarray(params.points_to_predict, dtype=float)

--- a/tests/benchmarks/test_strainmap.py
+++ b/tests/benchmarks/test_strainmap.py
@@ -255,7 +255,7 @@ def run_simulation(
             points_to_predict=INITIAL_POINTS_TO_PREDICT,
         ),
     )
-    surrogate_mean, surrogate_std, _ = dial_core.get_surrogate_values(data, model)
+    surrogate_mean, surrogate_std, _, _ = dial_core.get_surrogate_values(data, model)
     mean_grid = np.array(surrogate_mean).reshape((-1, 1))
 
     # subtract the true values and save mean absolute error and standard deviation

--- a/tests/unit/test_internals.py
+++ b/tests/unit/test_internals.py
@@ -648,7 +648,7 @@ def test_hypercube_multiple_points(backend):
 def test_surrogate(backend, expected_means, expected_stddevs, expected_raw_stddevs):
     data = prediction_1D(backend)
     model = core.train_model(data)
-    means, stddevs, raw_stddevs = core.get_surrogate_values(data, model)
+    means, stddevs, raw_stddevs, _ = core.get_surrogate_values(data, model)
     assert means == pytest.approx(expected_means)
     assert stddevs[1:4] == pytest.approx(expected_stddevs)
     assert raw_stddevs[1:4] == pytest.approx(expected_raw_stddevs)

--- a/tests/unit/test_internals.py
+++ b/tests/unit/test_internals.py
@@ -1,3 +1,4 @@
+import math
 from math import e as E_CONSTANT
 
 import numpy as np
@@ -476,12 +477,14 @@ def test_hypercube_single_point(backend):
         output = core.get_next_point(data, model)
         assert len(output) == 1
         output = output[0]
+        assert output != last_point
         if last_point is not None:
             if i % DEFAULT_HYPERCUBE_VAL != 0:
                 assert output > last_point
             else:
                 assert last_point > output
         assert 1 <= output <= 2
+        data.point_index += 1
 
 
 @pytest.mark.parametrize(
@@ -531,6 +534,7 @@ def test_hypercube_single_point_discrete(backend):
         output = core.get_next_point(data, model)
         assert len(output) == 1
         output = output[0]
+        assert output != last_point
         if last_point is not None:
             if i % data.discrete_measurement_grid_size[0] != 0:
                 assert output > last_point
@@ -541,6 +545,42 @@ def test_hypercube_single_point_discrete(backend):
         assert 0 <= output <= 59
         assert int(output) == output
         assert output in np.arange(60).astype(float)
+        data.point_index += 1
+
+
+@pytest.mark.parametrize(
+    ('backend'),
+    [
+        ('sklearn'),
+        ('gpax'),
+    ],
+)
+def test_hypercube_single_point_discrete_2D(backend):
+    data = single_2D_discrete_grid(
+        backend,
+        strategy='hypercube',
+        strategy_args=None,
+        discrete_measurement_grid_size=[6, 6],
+    )
+    model = core.train_model(data)
+    output = None
+    last_point = None
+    num_points = math.prod(data.discrete_measurement_grid_size)
+    for i in range(100):
+        last_point = output
+        output = core.get_next_point(data, model)
+        assert len(output) == 2
+        assert output != last_point
+        if last_point is not None:
+            if i % num_points != 0:
+                assert output[0] > last_point[0] or output[1] > last_point[1]
+            else:
+                assert last_point[0] > output[0] or last_point[1] > output[1]
+        for o in output:
+            assert 0 <= o <= 59
+            assert int(o) == o
+            assert o in np.arange(60).astype(float)
+        data.point_index += 1
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_internals.py
+++ b/tests/unit/test_internals.py
@@ -87,7 +87,11 @@ def single_1D_discrete_grid(backend, strategy, strategy_args, discrete_measureme
     return ServersideInputSingle(workflow_state, params)
 
 
-def single_2D(backend, strategy, strategy_args, discrete_measurement_grid_size=None):
+def single_2D(
+    backend,
+    strategy,
+    strategy_args,
+):
     workflow_state = DialWorkflowCreationParamsService(
         dataset_x=[
             [0.9317758694133622, -0.23597335497782845],
@@ -134,8 +138,69 @@ def single_2D(backend, strategy, strategy_args, discrete_measurement_grid_size=N
         strategy=strategy,
         strategy_args=strategy_args,
         bounds=[[-2, 2], [-2, 2]],
-        discrete_measurements=bool(discrete_measurement_grid_size),
-        discrete_measurement_grid_size=discrete_measurement_grid_size or [20, 20],
+        seed=42,
+    )
+    return ServersideInputSingle(workflow_state, params)
+
+
+def single_2D_discrete_grid(
+    backend,
+    strategy,
+    strategy_args,
+    discrete_measurement_grid_size,
+):
+    bounds = [
+        [0, discrete_measurement_grid_size[0] - 1],
+        [0, discrete_measurement_grid_size[1] - 1],
+    ]
+    workflow_state = DialWorkflowCreationParamsService(
+        dataset_x=[
+            [0.9317758694133622, -0.23597335497782845],
+            [-0.7569874398003542, -0.76891211613756],
+            [-0.38457336507729645, -1.1327391183311766],
+            [-0.9293590899359039, 0.25039725076881014],
+            [1.984696498789749, -1.7147926093003538],
+            [1.2001856430453541, 1.572387611848939],
+            [0.5080666898409634, -1.566722183270571],
+            [-1.871124738716507, 1.9022651997285078],
+            [-1.572941300813352, 1.0014173171150125],
+            [0.033053333077524005, 0.44682040004191537],
+        ],
+        dim_x=2,
+        dataset_y=[
+            2.08609604,
+            2.26284928,
+            2.21989834,
+            1.61634392,
+            3.50481457,
+            0.25065034,
+            2.52277171,
+            2.42139515,
+            2.34930184,
+            1.31811177,
+        ],
+        bounds=bounds,
+        kernel='rbf',
+        kernel_args={
+            'length_scale': 0.15,
+            'length_scale_bounds': 'fixed',
+            'noise_level': 0.0,
+            'noise_level_bounds': 'fixed',
+            'constant_value': 1.0,
+            'constant_value_bounds': 'fixed',
+        },
+        backend=backend,
+        preprocess_standardize=True,
+        y_is_good=True,
+        seed=42,
+    )
+    params = DialInputSingleOtherStrategy(
+        workflow_id=DUMMY_WORKFLOW_ID,
+        strategy=strategy,
+        strategy_args=strategy_args,
+        bounds=bounds,
+        discrete_measurements=True,
+        discrete_measurement_grid_size=discrete_measurement_grid_size,
         seed=42,
     )
     return ServersideInputSingle(workflow_state, params)
@@ -398,6 +463,34 @@ def test_random(backend):
         ('gpax'),
     ],
 )
+def test_hypercube_single_point(backend):
+    data = single_1D(backend, strategy='hypercube', strategy_args=None)
+    model = core.train_model(data)
+    output = None
+    last_point = None
+    DEFAULT_HYPERCUBE_VAL = (
+        4  # hypercube sets this parameter by default if no discrete grid provided
+    )
+    for i in range(100):
+        last_point = output
+        output = core.get_next_point(data, model)
+        assert len(output) == 1
+        output = output[0]
+        if last_point is not None:
+            if i % DEFAULT_HYPERCUBE_VAL != 0:
+                assert output > last_point
+            else:
+                assert last_point > output
+        assert 1 <= output <= 2
+
+
+@pytest.mark.parametrize(
+    ('backend'),
+    [
+        ('sklearn'),
+        ('gpax'),
+    ],
+)
 def test_random_discrete(backend):
     data = single_1D_discrete_grid(
         backend,
@@ -423,6 +516,40 @@ def test_random_discrete(backend):
         ('gpax'),
     ],
 )
+def test_hypercube_single_point_discrete(backend):
+    data = single_1D_discrete_grid(
+        backend,
+        strategy='hypercube',
+        strategy_args=None,
+        discrete_measurement_grid_size=[60],
+    )
+    model = core.train_model(data)
+    output = None
+    last_point = None
+    for i in range(100):
+        last_point = output
+        output = core.get_next_point(data, model)
+        assert len(output) == 1
+        output = output[0]
+        if last_point is not None:
+            if i % data.discrete_measurement_grid_size[0] != 0:
+                assert output > last_point
+            else:
+                assert last_point > output
+        # assert output[0] in _measurement_grid
+        # assert output[0] == int(output[0])
+        assert 0 <= output <= 59
+        assert int(output) == output
+        assert output in np.arange(60).astype(float)
+
+
+@pytest.mark.parametrize(
+    ('backend'),
+    [
+        ('sklearn'),
+        ('gpax'),
+    ],
+)
 def test_random_points(backend):
     data = multiple_2D(backend, strategy='random')
     model = core.initialize_model(data)
@@ -438,7 +565,7 @@ def test_random_points(backend):
         # ('gpax'),
     ],
 )
-def test_hypercube(backend):
+def test_hypercube_multiple_points(backend):
     data = multiple_2D(backend, strategy='hypercube')
     model = core.initialize_model(data)
     points = core.get_next_points(data, model)


### PR DESCRIPTION
Want this to be a PR instead of a hotfix develop push because this changes the output structure of `get_surrogate_values` (dataclass only). `get_surrogate_values()` should in theory handle any N-dimensional data structure, and we also don't necessarily want to couple its return value to `get_next_point` or `get_next_points`, so I went ahead and created a custom return class for it. 

(The CI action is temporary and will be reverted after this MR is approved)

Closes #40 